### PR TITLE
feat(--insecure) Allow insecure connections / no certificate validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Options:
   -T, --timeout INTEGER    Request timeout in seconds
   -a, --accept TEXT        Accept header value
   -j, --json               Report in JSON
+  -k, --insecure           Don't verify certificates
   -b, --body               Show response body
   -L, --link-type TEXT     Follow link header with type
   -R, --link-rel TEXT      Follow link header with rel

--- a/htrace/__main__.py
+++ b/htrace/__main__.py
@@ -15,7 +15,7 @@ B  = '\033[34m' # blue
 P  = '\033[35m' # purple
 
 #Global for access by event hooks
-session = requests.Session()    
+session = requests.Session()
 
 def printSummary(s):
     L = logging.getLogger("SUMMARY:")
@@ -69,13 +69,14 @@ def cbLinkFollow(response, *args, **kwargs):
 @click.option("-T", "--timeout", default=10, help="Request timeout in seconds")
 @click.option("-a", "--accept", default="*/*", help="Accept header value")
 @click.option("-j", "--json", "json_report", is_flag=True, help="Report in JSON")
+@click.option("-k", "--insecure", default=False, is_flag=True, help="Don't verify certificates")
 @click.option("-b", "--body", is_flag=True, help="Show response body")
 @click.option("-L", "--link-type", default=None, help="Follow link header with type")
 @click.option("-R", "--link-rel", default='alternate', help="Follow link header with rel")
 @click.option("-P", "--link-profile", default=None, help="Follow link header with profile")
-def main(url, timeout, accept, json_report, body, link_type, link_rel, link_profile):
+def main(url, timeout, accept, json_report, insecure, body, link_type, link_rel, link_profile):
     logging.basicConfig(
-        level=logging.INFO, 
+        level=logging.INFO,
         format="%(asctime)s.%(msecs)03d:%(name)s %(message)s",
         datefmt='%Y-%m-%d %H:%M:%S')
     accept = htrace.ACCEPT_VALUES.get(accept, accept)
@@ -89,11 +90,11 @@ def main(url, timeout, accept, json_report, body, link_type, link_rel, link_prof
     }
     tstart = time.time()
     session._extra = {
-        'link_type':link_type, 
-        'link_rel': link_rel, 
+        'link_type':link_type,
+        'link_rel': link_rel,
         'link_profile': link_profile
     }
-    response = session.get(url, timeout=timeout, headers=headers, hooks=hooks, allow_redirects=True)
+    response = session.get(url, timeout=timeout, headers=headers, hooks=hooks, allow_redirects=True, verify=not insecure)
     tend = time.time()
     summary = htrace.responseSummary(response, tstart, tend)
     if json_report:

--- a/htrace/__main__.py
+++ b/htrace/__main__.py
@@ -6,6 +6,7 @@ import requests
 import json
 import time
 import urllib.parse
+import urllib3
 
 W  = '\033[0m'  # white (normal)
 R  = '\033[31m' # red
@@ -75,6 +76,9 @@ def cbLinkFollow(response, *args, **kwargs):
 @click.option("-R", "--link-rel", default='alternate', help="Follow link header with rel")
 @click.option("-P", "--link-profile", default=None, help="Follow link header with profile")
 def main(url, timeout, accept, json_report, insecure, body, link_type, link_rel, link_profile):
+    if insecure:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s.%(msecs)03d:%(name)s %(message)s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "htrace"
-version = "0.2.1"
+version = "0.2.2"
 description = "Tracing HTTP requests over redirects, link headers"
 authors = ["datadavev <605409+datadavev@users.noreply.github.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
* Often convenient and important to test a specific web server,
  as addressed by direct IP address or a DNS address which isn't a
  site's primary / canonical DNS name. If HTTPS/TLS certificates are
  being strictly verified, `htrace` will error out, providing the
  developer no net information.
* This commit adds a `-k` / `--insecure` flag, modeled after a similar
  flag to the `curl` command, instructing `htrace` to **not** verify
  certificates. Using this flag, test server and DNS configurations can
  be tested and traced.